### PR TITLE
support pushing to custom registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,10 @@
 
 .PHONY: all driver-registrar clean test
 
-IMAGE_NAME=quay.io/k8scsi/driver-registrar
+REGISTRY_NAME=quay.io/k8scsi
+IMAGE_NAME=driver-registrar
 IMAGE_VERSION=canary
+IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 
 REV=$(shell git describe --long --match='v*' --dirty)
 
@@ -37,10 +39,10 @@ clean:
 
 container: driver-registrar
 	cp bin/driver-registrar deploy/docker
-	docker build -t $(IMAGE_NAME):$(IMAGE_VERSION) deploy/docker
+	docker build -t $(IMAGE_TAG) deploy/docker
 
 push: container
-	docker push $(IMAGE_NAME):$(IMAGE_VERSION)
+	docker push $(IMAGE_TAG)
 
 test:
 	go test `go list ./... | grep -v 'vendor'` $(TESTARGS)


### PR DESCRIPTION
Developers who want to try out locally modified code need to push into
their own registry. By composing the image tag from makefile
variables, that becomes possible with:

  make REGISTRY_NAME=localhost:5000 push

Related-to: kubernetes-csi/docs#23