### PR TITLE
Revert "Update release to v0.3.0"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@
 
 REGISTRY_NAME=quay.io/k8scsi
 IMAGE_NAME=driver-registrar
-IMAGE_VERSION=v0.3.0
+IMAGE_VERSION=canary
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 
-REV=$(shell git describe --long --tags --match='v*' --dirty)
+REV=$(shell git describe --long --match='v*' --dirty)
 
 ifdef V
 TESTARGS = -v -args -alsologtostderr -v 5


### PR DESCRIPTION
Reverts kubernetes-csi/driver-registrar#33

because of failing CI