### PR TITLE
Lock travis.ci go version to 1.10.3 and add soft tag to revision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 services:
   - docker
 go:
-  - 1.x
+  - 1.10.3
 script:
   - go fmt $(go list ./... | grep -v vendor) | wc -l | grep 0
   - make test

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ IMAGE_NAME=driver-registrar
 IMAGE_VERSION=canary
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 
-REV=$(shell git describe --long --match='v*' --dirty)
+REV=$(shell git describe --long --tags --match='v*' --dirty)
 
 ifdef V
 TESTARGS = -v -args -alsologtostderr -v 5


### PR DESCRIPTION
/assign @lpabon @jsafrane 

travis.ci needs to be locked to 1.10.3 because previously it was defaulting to a beta 1.11.x version that had `go fmt` issues