### PR TITLE
Report node update error

### DIFF
--- a/cmd/driver-registrar/node_register.go
+++ b/cmd/driver-registrar/node_register.go
@@ -117,10 +117,13 @@ func nodeRegister(
 		signal.Notify(c, os.Interrupt)
 		go func() {
 			<-c
-			getVerifyAndDeleteNodeId(
+			err := getVerifyAndDeleteNodeId(
 				k8sNodeName,
 				k8sNodesClient,
 				csiDriverName)
+			if err != nil {
+				glog.Warning(err)
+			}
 			os.Exit(1)
 		}()
 
@@ -132,11 +135,14 @@ func nodeRegister(
 		// The CSI driver name and node ID are assumed to be immutable, and are not
 		// refetched on subsequent loop iterations.
 		for {
-			getVerifyAndAddNodeId(
+			err := getVerifyAndAddNodeId(
 				k8sNodeName,
 				k8sNodesClient,
 				csiDriverName,
 				csiDriverNodeId)
+			if err != nil {
+				glog.Warning(err)
+			}
 			time.Sleep(sleepDuration)
 		}
 	}


### PR DESCRIPTION
The registrar should report some error when it fails to update Node object.

Fixes: #8

Before:
```
I1002 14:35:18.586002       1 main.go:207] Loading kubeconfig.
I1002 14:35:18.588513       1 main.go:220] Attempt to update node annotation if needed
I1002 14:35:18.605598       1 main.go:275] previousAnnotationValue=""
```
(and silence)

After:
```
I1002 14:40:53.080648       1 node_register.go:112] Attempt to update node annotation if needed
I1002 14:40:53.103875       1 node_register.go:175] previousAnnotationValue=""
W1002 14:40:53.109056       1 node_register.go:144] Node update failed: nodes "dev-jsafrane-master-etcd-nfs-1" is forbidden: User "system:serviceaccount:default:csidriverdeployment-sample" cannot update nodes at the cluster scope: no RBAC policy matched
```