### PR TITLE
Set dependency based on a tag kubernetes-1.12.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -375,7 +375,6 @@
   revision = "d65f4428c04f2d28f924a47d1d2177d0cbf45a16"
 
 [[projects]]
-  branch = "release-1.12"
   digest = "1:7aa037a4df5432be2820d164f378d7c22335e5cbba124e90e42114757ebd11ac"
   name = "k8s.io/apimachinery"
   packages = [
@@ -418,9 +417,10 @@
   ]
   pruneopts = ""
   revision = "6dd46049f39503a1fc8d65de4bd566829e95faff"
+  version = "kubernetes-1.12.0"
 
 [[projects]]
-  digest = "1:f750eea76a41b0d4fcf8ba4a8df3bd3158b96c6179991408ae596433f772f297"
+  digest = "1:5d4153d12c3aed2c90a94262520d2498d5afa4d692554af55e65a7c5af0bc399"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -480,12 +480,11 @@
     "util/retry",
   ]
   pruneopts = ""
-  revision = "f95740e171023a8be8649df0e40ece69cd095bd8"
-  version = "kubernetes-1.12.0-rc.2"
+  revision = "1638f8970cefaa404ff3a62950f88b08292b2696"
+  version = "kubernetes-1.12.0"
 
 [[projects]]
-  branch = "release-1.12"
-  digest = "1:0b90e0e4c36bb8ea5e69a3c3cde149b5afd21eddcf95e020cd3febf79312f11c"
+  digest = "1:6b29915b728f47c182c1992c15c508e4ac9945c0f3457b1173b813708638e571"
   name = "k8s.io/csi-api"
   packages = [
     "pkg/apis/csi/v1alpha1",
@@ -495,7 +494,8 @@
     "pkg/crd",
   ]
   pruneopts = ""
-  revision = "833a598b67614ffea5b04ec1fc5bc3e5f6883e56"
+  revision = "daa9d551756f72a51f887db9485ec2b2575f47e4"
+  version = "kubernetes-1.12.0"
 
 [[projects]]
   digest = "1:d9c0b011a765fe7853b7c7fcd3aa2394ca4ff17f3f771e8f647e5fd95321e6ba"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,15 +37,15 @@
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  branch = "release-1.12"
+  version = "kubernetes-1.12.0"
 
 [[constraint]]
   name = "k8s.io/csi-api"
-  branch = "release-1.12"
+  version = "kubernetes-1.12.0"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "kubernetes-1.12.0-rc.2"
+  version = "kubernetes-1.12.0"
 
 [[override]]
   name = "github.com/json-iterator/go"

--- a/vendor/k8s.io/client-go/Godeps/Godeps.json
+++ b/vendor/k8s.io/client-go/Godeps/Godeps.json
@@ -272,131 +272,131 @@
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1beta2",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/authentication/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/authentication/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/authorization/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/authorization/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v2beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v2beta2",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v2alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/certificates/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/coordination/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/core/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/events/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/extensions/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/imagepolicy/v1alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/networking/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/policy/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/scheduling/v1alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/scheduling/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/settings/v1alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/apitesting",

--- a/vendor/k8s.io/csi-api/Godeps/Godeps.json
+++ b/vendor/k8s.io/csi-api/Godeps/Godeps.json
@@ -168,139 +168,139 @@
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1alpha1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1beta2",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/authentication/v1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/authentication/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/authorization/v1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/authorization/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v2beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v2beta2",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v2alpha1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/certificates/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/coordination/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/core/v1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/events/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/extensions/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/networking/v1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/policy/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1alpha1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/scheduling/v1alpha1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/scheduling/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/settings/v1alpha1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1alpha1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1beta1",
-			"Rev": "b9bd491cc8f21b9461d2a6cf277542dc4c53e7fc"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions",
-			"Rev": "ba97476c935ff6cad73c1dfa3463ecca13a19148"
+			"Rev": "1748dfb29e8a4432b78514bc88a1b07937a9805a"
 		},
 		{
 			"ImportPath": "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
-			"Rev": "ba97476c935ff6cad73c1dfa3463ecca13a19148"
+			"Rev": "1748dfb29e8a4432b78514bc88a1b07937a9805a"
 		},
 		{
 			"ImportPath": "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme",
-			"Rev": "ba97476c935ff6cad73c1dfa3463ecca13a19148"
+			"Rev": "1748dfb29e8a4432b78514bc88a1b07937a9805a"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
@@ -472,91 +472,91 @@
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery/fake",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/scheme",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/clientauthentication",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/version",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/plugin/pkg/client/auth/exec",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest/watch",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/testing",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/cache",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/metrics",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/pager",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/transport",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/buffer",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/cert",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/connrotation",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/flowcontrol",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/integer",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/retry",
-			"Rev": "3e32c8333043fc2c058455f4d32986a89d31b05b"
+			"Rev": "1638f8970cefaa404ff3a62950f88b08292b2696"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",


### PR DESCRIPTION
This PR updates the Gopkg.yaml file to point to the kubernetes-1.12.0 tag
because content on the release-1.12 branch could be changing over time.