### PR TITLE
deploy: add RBAC definitions

### DIFF
--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -1,0 +1,51 @@
+# This YAML file contains all RBAC objects that are necessary to run external
+# CSI provisioner.
+#
+# In production, each CSI driver deployment has to be customized:
+# - to avoid conflicts, use non-default namespace and different names
+#   for non-namespaced entities like the ClusterRole
+# - decide whether the deployment replicates the external CSI
+#   provisioner, in which case leadership election must be enabled;
+#   this influences the RBAC setup, see below
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-driver-registrar
+  # replace with non-default namespace name
+  namespace: default
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: driver-registrar-runner
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  # The following permissions are only needed when running
+  # driver-registrar without the --kubelet-registration-path
+  # parameter, i.e. when using driver-registrar instead of
+  # kubelet to update the csi.volume.kubernetes.io/nodeid
+  # annotation. That mode of operation is going to be deprecated
+  # and should not be used anymore, but is needed on older
+  # Kubernetes versions.
+  # - apiGroups: [""]
+  #   resources: ["nodes"]
+  #   verbs: ["get", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-driver-registrar-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-driver-registrar
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: driver-registrar-runner
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
As discussed in the Kubernetes CSI working group, each sidecar
container should document the RBAC definitions that are needed to
run the sidecar app.