### PR TITLE
Refactor connection with retries and backoff

### DIFF
--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
@@ -48,7 +49,8 @@ func createMockServer(t *testing.T) (
 
 	// Create a client connection to it
 	addr := drv.Address()
-	csiConn, err := NewConnection(addr, 10)
+	t.Log("Connecting to ", addr)
+	csiConn, err := NewConnection(addr, time.Millisecond*50)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, err
 	}


### PR DESCRIPTION
This PR attempts to fix https://github.com/kubernetes-csi/driver-registrar/issues/76
It retries to connect to the driver (within the same session) several times before giving up.  The logic is as follows:

  - Within `apimachinery/wait.ExponentialBackoff` condition do `5 times`:
    - Attempt to connect with DialContext:
       - Block until a connection is successful
       - Give up if `--connection-timeout` reached 
    - Evaluate any error from DialContext, if retryable:
        - Attempt to reconnect (based on error type)
    - If not, giveup right away
    - if number of attempts reached
        - Give up, stop
        - Else try again

Return successful connection or error if one was generated 

Using flag `--connection-timeout` can be used to control how long a connection request lasts before the gives up and try again.  Because this will retry right away, 5 times total, flag `--connection-timeout` should be set to a sensible value, something like `5 to 10 secs`.  For instance a `5 second time out` will produce the following total attempt time:

` total connection attempt time ≈  5 sec * 5 attempts * backoffFactor ` if no connection is created within that time period, the code will stop.