### PR TITLE
Default value of k8sAttachmentRequired fix

### DIFF
--- a/cmd/driver-registrar/main.go
+++ b/cmd/driver-registrar/main.go
@@ -58,7 +58,7 @@ var (
 		"to register the CSI driver with Kubernetes. This mode requires that this "+
 		"container be run in a StateFul set of 1, and not in a DaemonSet.")
 	k8sAttachmentRequired = flag.Bool("driver-requires-attachment",
-		true,
+		false,
 		"Indicates this CSI volume driver requires an attach operation (because it "+
 			"implements the CSI ControllerPublishVolume() method), and that Kubernetes "+
 			"should call attach and wait for any attach operation to complete before "+


### PR DESCRIPTION
The default value of k8sAttachmentRequired was set to True while the description was mentioning that by default it should be set to false. This PR corrects the default value to match the description.